### PR TITLE
styling change to make decimal counting text readable

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -54,6 +54,12 @@ body, html {
   }
 }
 
+.btn.btn-success {
+  .text-secondary {
+    color: #fff !important;
+  }
+}
+
 .bg-simple-gradient {
   background: $simple-gradient;
 }


### PR DESCRIPTION
Tiny fix for this odd, unreadable text I saw. Not thrilled about the use of `!important` but it seems like this is the current state of styling, which is fine. :)

Text before:

<img width="294" alt="Screen Shot 2021-07-26 at 10 02 24 PM" src="https://user-images.githubusercontent.com/1042667/127099450-aae2fe79-2c56-46af-8e9b-e18d667cccb3.png">

Text after:

<img width="315" alt="Screen Shot 2021-07-26 at 10 16 03 PM" src="https://user-images.githubusercontent.com/1042667/127099478-881545d9-833f-4021-a906-374d00c7f532.png">
